### PR TITLE
Optimize MicroBuild Signing

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,6 +16,16 @@
 
   <Import
       Project="$([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory))).override.targets"
-      Condition=" Exists('$([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory))).override.targets') "
-  />
+      Condition=" Exists('$([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory))).override.targets') "/>
+    
+  <!--
+  By creating this target, we can ensure SignNugetFiles will run before SignFiles.
+  This ensures the output files (signed by SignFiles) will still look "more recent" than
+  the nuget files (signed by SignNugetFiles), which are considered inputs to the project.
+  If we don't do this and SignNugetFiles runs first, the inputs look more recent than the outputs and the
+  project will be rebuilt unnecessarily.
+  -->
+  <Target Name="EnforceNugetSigningBeforeOutputSigning" Condition="'$(MicroBuild_SigningEnabled)' == 'true' and @(NuGetFilesToSign)' != ''" BeforeTargets="SignFiles" DependsOnTargets="SignNugetFiles">
+      <Message Text="Enforing NuGet signing before output signing..." />
+  </Target>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -25,7 +25,7 @@
   If we don't do this and SignNugetFiles runs first, the inputs look more recent than the outputs and the
   project will be rebuilt unnecessarily.
   -->
-  <Target Name="EnforceNugetSigningBeforeOutputSigning" Condition="'$(MicroBuild_SigningEnabled)' == 'true' and @(NuGetFilesToSign)' != ''" BeforeTargets="SignFiles" DependsOnTargets="SignNugetFiles">
+  <Target Name="EnforceNugetSigningBeforeOutputSigning" Condition="'$(MicroBuild_SigningEnabled)' == 'true' and '@(NuGetFilesToSign)' != ''" BeforeTargets="SignFiles" DependsOnTargets="SignNugetFiles">
       <Message Text="Enforing NuGet signing before output signing..." />
   </Target>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -17,15 +17,6 @@
   <Import
       Project="$([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory))).override.targets"
       Condition=" Exists('$([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory))).override.targets') "/>
-    
-  <!--
-  By creating this target, we can ensure SignNugetFiles will run before SignFiles.
-  This ensures the output files (signed by SignFiles) will still look "more recent" than
-  the nuget files (signed by SignNugetFiles), which are considered inputs to the project.
-  If we don't do this and SignNugetFiles runs first, the inputs look more recent than the outputs and the
-  project will be rebuilt unnecessarily.
-  -->
-  <Target Name="EnforceNugetSigningBeforeOutputSigning" Condition="'$(MicroBuild_SigningEnabled)' == 'true' and '@(NuGetFilesToSign)' != ''" BeforeTargets="SignFiles" DependsOnTargets="SignNugetFiles">
-      <Message Text="Enforing NuGet signing before output signing..." />
-  </Target>
+
+  <Import Project="RedundantSigningWorkarounds.targets" />
 </Project>

--- a/RedundantSigningWorkarounds.targets
+++ b/RedundantSigningWorkarounds.targets
@@ -48,6 +48,6 @@
 
   <Target Name="AddSignedIndicatorFileForNuget" AfterTargets="SignNuGetFiles">
     <!-- Create a text file next to each Nuget dll, which we will later use to determine that we already signed that NuGet -->
-    <WriteLinesToFile File="%(NuGetFilesToSign.Identity).txt" Lines="NuGet Signed"/>
+    <WriteLinesToFile File="%(NuGetFilesToSign.Identity).txt" Lines="NuGet Signed" Condition="'@(NuGetFilesToSign)' != ''"/>
   </Target>
 </Project>

--- a/RedundantSigningWorkarounds.targets
+++ b/RedundantSigningWorkarounds.targets
@@ -5,7 +5,7 @@
 
   This file contains a series of workarounds to reduce the amount of redundant compiling and signing we perform as a result of MicroBuild signing during the build.
 
-  Here is a scenario (without these workarounds) to walk through what issues this addresses:
+  Here is a scenario (without these workarounds) to walk through the issues this addresses:
   1. Project A references Nuget dll 1
       a. Meaning Nuget dll 1 is considered an *input* to Project A
   2. Project A is built
@@ -18,13 +18,13 @@
       a. i.e. Input file "/Users/runner/work/1/s/packages/guilabs.language.xml/1.2.46/lib/netstandard2.0/Microsoft.Language.Xml.dll" is newer than output file "obj/Release/netstandard2.0/Xamarin.AndroidDesigner.dll"
   8. As a result, compile runs, so signing runs, so we end up wasting a significant amount of time building & signing when we didn't need to…
 
-  In order to workaround this issue, we can:
+  In order to workaround these issues, we can:
   1. Ensure SignNugetFiles runs *before* CoreCompile. This way, the compiled output will still appear "more recent" than the signed nuget files.
       See targets: EnforceNugetSigningBeforeOutputSigning
   2. When signing files, drop a temp file next to it that tells us the file has been signed. If that temp file alread exists, prevent re-signing the file.
       See targets: AddSignedIndicatorFile, RemoveRedundantSigning, AddSignedIndicatorFileForNuget, RemoveRedundantSigningForNuget
 
-  Workaround #2 could be done differently, by disabling signing altogether until CoreCompile runs, but that breaks workaround #1, hence the temp file approach, instead.
+  Workaround #2 could be done differently for build output by disabling signing altogether until CoreCompile runs, but that breaks workaround #1, hence the temp file approach.
 
 -->
 
@@ -52,36 +52,26 @@
       <WriteLinesToFile File="$(SigningCompleteFile)" Lines="@(FilesToSign)"/>
   </Target>
 
-  <!--
-  By creating this target, we can ensure SignNugetFiles will run before CoreCompile.
-  -->
+  <!-- Ensure SignNugetFiles will run before CoreCompile. -->
   <Target Name="EnforceNugetSigningBeforeOutputSigning" Condition="'@(NuGetFilesToSign)' != ''" BeforeTargets="CoreCompile" DependsOnTargets="SignNugetFiles">
       <Message Text="Enforing NuGet signing before core compile..." />
   </Target>
 
+  <!-- Do not sign NuGet files that have already been signed. -->
   <Target Name="RemoveRedundantSigningForNuget" BeforeTargets="SignNugetFiles">
     <Message Text="Removing NugetFilesToSign where signing has already happened" />
-
-    <!-- Clear NuGetFilesToSign -->
     <ItemGroup>
-      <TempNugetFilesToSign Include="@(NuGetFilesToSign)" />
-      <NuGetFilesToSign Remove="@(NuGetFilesToSign)" />
-    </ItemGroup>
-
-    <!-- Repopulate NuGetFilesToSign only with nugets that do not already have the signing-complete indicator file -->
-    <ItemGroup>
-      <NugetFilesToSign Include="@(TempNugetFilesToSign)" Condition="!Exists('%(TempNugetFilesToSign.Identity).txt')" />
-      <TempNugetFilesToSign Remove="@(TempNugetFilesToSign)"/>
+      <NuGetFilesToSign Remove="@(NuGetFilesToSign)" Condition="Exists('%(NuGetFilesToSign.Identity).txt')" />
     </ItemGroup>
   </Target>
 
+  <!-- Create a temp file next to each Nuget dll, which indicates that we already signed the file -->
   <Target Name="AddSignedIndicatorFileForNuget" AfterTargets="SignNuGetFiles">
-    <!-- Create a text file next to each Nuget dll, which we will later use to determine that we already signed that NuGet -->
     <WriteLinesToFile File="%(NuGetFilesToSign.Identity).txt" Lines="NuGet Signed" Condition="'@(NuGetFilesToSign)' != ''"/>
   </Target>
 
   <!--
-    If CoreCompile does run, we need to clear the output dll signing file since the dll will get overwritten with an unsigned file.
+    If CoreCompile runs, we need to clear the output dll signing file since the dll will get overwritten with an unsigned file.
     We do *not* need to clear the nuget signing files, though. Those dlls should not get overwritten.
   -->
   <Target Name="ClearSigningTempFileIfCompileRuns">

--- a/RedundantSigningWorkarounds.targets
+++ b/RedundantSigningWorkarounds.targets
@@ -1,13 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+<!--
+
+  This file contains a series of workarounds to reduce the amount of redundant compiling and signing we perform as a result of MicroBuild signing during the build.
+
+  Here is a scenario (without these workarounds) to walk through what issues this addresses:
+  1. Project A references Nuget dll 1
+      a. Meaning Nuget dll 1 is considered an *input* to Project A
+  2. Project A is built
+  3. Project A's output dlls are signed (SignFiles target)
+  4. Project A's Nuget dll 1 is signed (SignNugetFiles target)
+      a. *Important note: this updates the file in the global packages folder. It is now "more recent" than Project A's output files.*
+  5. Later in the build, another project references Project A, so Project A is built again
+  6. Normally, MSBuild would see that Project A has already been built and skip compile
+  7. In reality, however, MSBuild sees that the Nuget dll 1 input file is more recent than the Project A's output files, so it thinks it needs to build again:
+      a. i.e. Input file "/Users/runner/work/1/s/packages/guilabs.language.xml/1.2.46/lib/netstandard2.0/Microsoft.Language.Xml.dll" is newer than output file "obj/Release/netstandard2.0/Xamarin.AndroidDesigner.dll"
+  8. As a result, compile runs, so signing runs, so we end up wasting a significant amount of time building & signing when we didn't need to…
+
+  In order to workaround this issue, we can:
+  1. Ensure SignNugetFiles runs *before* CoreCompile. This way, the compiled output will still appear "more recent" than the signed nuget files.
+      See targets: EnforceNugetSigningBeforeOutputSigning
+  2. When signing files, drop a temp file next to it that tells us the file has been signed. If that temp file alread exists, prevent re-signing the file.
+      See targets: AddSignedIndicatorFile, RemoveRedundantSigning, AddSignedIndicatorFileForNuget, RemoveRedundantSigningForNuget
+
+  Workaround #2 could be done differently, by disabling signing altogether until CoreCompile runs, but that breaks workaround #1, hence the temp file approach, instead.
+
+-->
+
   <PropertyGroup>
     <SigningCompleteFile>$(OutDir)\signing-completed.txt</SigningCompleteFile>
+    
+    <TargetsTriggeredByCompilation>
+        $(TargetsTriggeredByCompilation);
+        ClearSigningTempFileIfCompileRuns
+    </TargetsTriggeredByCompilation>
   </PropertyGroup>
 
   <!--
     RemoveRedundantSigning and AddSignedIndicatorFile ensure we don't sign build output multiple times.
-    Once signing is complete, we add a temp file.
-    If the temp file is already present, we skip signing.
+    Once signing is complete, we add a temp file. If the temp file is already present, we skip signing.
     -->
   <Target Name="RemoveRedundantSigning" BeforeTargets="SignFiles" Condition="Exists($(SigningCompleteFile))">
     <Message Text="Removing all FilesToSign, signing has already happened" Importance="High" />
@@ -22,15 +54,12 @@
 
   <!--
   By creating this target, we can ensure SignNugetFiles will run before CoreCompile.
-  This ordering ensures the build's output files will still look "more recent" than the nuget files.
-  Without it, signing "updates" the nuget files and makes them look newer than the output, and since
-  the nuget dlls are considered an input, MSBuild sees that update and thinks it needs to rebuild unnecessarily.
   -->
   <Target Name="EnforceNugetSigningBeforeOutputSigning" Condition="'@(NuGetFilesToSign)' != ''" BeforeTargets="CoreCompile" DependsOnTargets="SignNugetFiles">
       <Message Text="Enforing NuGet signing before core compile..." />
   </Target>
 
-  <Target Name="RemoveRedundantNugetSigning" BeforeTargets="SignNugetFiles">
+  <Target Name="RemoveRedundantSigningForNuget" BeforeTargets="SignNugetFiles">
     <Message Text="Removing NugetFilesToSign where signing has already happened" />
 
     <!-- Clear NuGetFilesToSign -->
@@ -49,5 +78,14 @@
   <Target Name="AddSignedIndicatorFileForNuget" AfterTargets="SignNuGetFiles">
     <!-- Create a text file next to each Nuget dll, which we will later use to determine that we already signed that NuGet -->
     <WriteLinesToFile File="%(NuGetFilesToSign.Identity).txt" Lines="NuGet Signed" Condition="'@(NuGetFilesToSign)' != ''"/>
+  </Target>
+
+  <!--
+    If CoreCompile does run, we need to clear the output dll signing file since the dll will get overwritten with an unsigned file.
+    We do *not* need to clear the nuget signing files, though. Those dlls should not get overwritten.
+  -->
+  <Target Name="ClearSigningTempFileIfCompileRuns">
+    <Message Text="Removing signing complete indicator file because CoreCompile ran..." />
+    <Delete Files="$(SigningCompleteFile)" />
   </Target>
 </Project>

--- a/RedundantSigningWorkarounds.targets
+++ b/RedundantSigningWorkarounds.targets
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SigningCompleteFile>$(OutDir)\signing-completed.txt</SigningCompleteFile>
+  </PropertyGroup>
+
+  <!--
+    RemoveRedundantSigning and AddSignedIndicatorFile ensure we don't sign build output multiple times.
+    Once signing is complete, we add a temp file.
+    If the temp file is already present, we skip signing.
+    -->
+  <Target Name="RemoveRedundantSigning" BeforeTargets="SignFiles" Condition="Exists($(SigningCompleteFile))">
+    <Message Text="Removing all FilesToSign, signing has already happened" Importance="High" />
+    <ItemGroup>
+      <FilesToSign Remove="@(FilesToSign)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="AddSignedIndicatorFile" AfterTargets="SignFiles">
+      <WriteLinesToFile File="$(SigningCompleteFile)" Lines="@(FilesToSign)"/>
+  </Target>
+
+  <!--
+  By creating this target, we can ensure SignNugetFiles will run before CoreCompile.
+  This ordering ensures the build's output files will still look "more recent" than the nuget files.
+  Without it, signing "updates" the nuget files and makes them look newer than the output, and since
+  the nuget dlls are considered an input, MSBuild sees that update and thinks it needs to rebuild unnecessarily.
+  -->
+  <Target Name="EnforceNugetSigningBeforeOutputSigning" Condition="'@(NuGetFilesToSign)' != ''" BeforeTargets="CoreCompile" DependsOnTargets="SignNugetFiles">
+      <Message Text="Enforing NuGet signing before core compile..." />
+  </Target>
+
+  <Target Name="RemoveRedundantNugetSigning" BeforeTargets="SignNugetFiles">
+    <Message Text="Removing NugetFilesToSign where signing has already happened" />
+
+    <!-- Clear NuGetFilesToSign -->
+    <ItemGroup>
+      <TempNugetFilesToSign Include="@(NuGetFilesToSign)" />
+      <NuGetFilesToSign Remove="@(NuGetFilesToSign)" />
+    </ItemGroup>
+
+    <!-- Repopulate NuGetFilesToSign only with nugets that do not already have the signing-complete indicator file -->
+    <ItemGroup>
+      <NugetFilesToSign Include="@(TempNugetFilesToSign)" Condition="!Exists('%(TempNugetFilesToSign.Identity).txt')" />
+      <TempNugetFilesToSign Remove="@(TempNugetFilesToSign)"/>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="AddSignedIndicatorFileForNuget" AfterTargets="SignNuGetFiles">
+    <!-- Create a text file next to each Nuget dll, which we will later use to determine that we already signed that NuGet -->
+    <WriteLinesToFile File="%(NuGetFilesToSign.Identity).txt" Lines="NuGet Signed"/>
+  </Target>
+</Project>

--- a/RedundantSigningWorkarounds.targets
+++ b/RedundantSigningWorkarounds.targets
@@ -3,28 +3,13 @@
 
 <!--
 
-  This file contains a series of workarounds to reduce the amount of redundant compiling and signing we perform as a result of MicroBuild signing during the build.
+  This file contains a workaround to reduce the amount of redundant signing we perform as a result of MicroBuild signing during the build.
+  
+  When Project A attempts to build a dependent Project B, MSBuild will usually check to see if Project B has already been built and no-op the compile if it has.
+  However, signing will still run on the outputs, which means we end up re-signing files that have already been signed.
+  To avoid this, we can drop a temp file next to the signed output, which tells us the file has been signed. Then, we skip signing if the file already exists.
 
-  Here is a scenario (without these workarounds) to walk through the issues this addresses:
-  1. Project A references Nuget dll 1
-      a. Meaning Nuget dll 1 is considered an *input* to Project A
-  2. Project A is built
-  3. Project A's output dlls are signed (SignFiles target)
-  4. Project A's Nuget dll 1 is signed (SignNugetFiles target)
-      a. *Important note: this updates the file in the global packages folder. It is now "more recent" than Project A's output files.*
-  5. Later in the build, another project references Project A, so Project A is built again
-  6. Normally, MSBuild would see that Project A has already been built and skip compile
-  7. In reality, however, MSBuild sees that the Nuget dll 1 input file is more recent than the Project A's output files, so it thinks it needs to build again:
-      a. i.e. Input file "/Users/runner/work/1/s/packages/guilabs.language.xml/1.2.46/lib/netstandard2.0/Microsoft.Language.Xml.dll" is newer than output file "obj/Release/netstandard2.0/Xamarin.AndroidDesigner.dll"
-  8. As a result, compile runs, so signing runs, so we end up wasting a significant amount of time building & signing when we didn't need to…
-
-  In order to workaround these issues, we can:
-  1. Ensure SignNugetFiles runs *before* CoreCompile. This way, the compiled output will still appear "more recent" than the signed nuget files.
-      See targets: EnforceNugetSigningBeforeOutputSigning
-  2. When signing files, drop a temp file next to it that tells us the file has been signed. If that temp file alread exists, prevent re-signing the file.
-      See targets: AddSignedIndicatorFile, RemoveRedundantSigning, AddSignedIndicatorFileForNuget, RemoveRedundantSigningForNuget
-
-  Workaround #2 could be done differently for build output by disabling signing altogether until CoreCompile runs, but that breaks workaround #1, hence the temp file approach.
+  Another approach would be to disable signing altogether unless CoreCompile runs, but that breaks additional workarounds used in projects that have this as a submodule, hence the temp file approach.
 
 -->
 
@@ -50,24 +35,6 @@
 
   <Target Name="AddSignedIndicatorFile" AfterTargets="SignFiles">
       <WriteLinesToFile File="$(SigningCompleteFile)" Lines="@(FilesToSign)"/>
-  </Target>
-
-  <!-- Ensure SignNugetFiles will run before CoreCompile. -->
-  <Target Name="EnforceNugetSigningBeforeOutputSigning" Condition="'@(NuGetFilesToSign)' != ''" BeforeTargets="CoreCompile" DependsOnTargets="SignNugetFiles">
-      <Message Text="Enforing NuGet signing before core compile..." />
-  </Target>
-
-  <!-- Do not sign NuGet files that have already been signed. -->
-  <Target Name="RemoveRedundantSigningForNuget" BeforeTargets="SignNugetFiles">
-    <Message Text="Removing NugetFilesToSign where signing has already happened" />
-    <ItemGroup>
-      <NuGetFilesToSign Remove="@(NuGetFilesToSign)" Condition="Exists('%(NuGetFilesToSign.Identity).txt')" />
-    </ItemGroup>
-  </Target>
-
-  <!-- Create a temp file next to each Nuget dll, which indicates that we already signed the file -->
-  <Target Name="AddSignedIndicatorFileForNuget" AfterTargets="SignNuGetFiles">
-    <WriteLinesToFile File="%(NuGetFilesToSign.Identity).txt" Lines="NuGet Signed" Condition="'@(NuGetFilesToSign)' != ''"/>
   </Target>
 
   <!--


### PR DESCRIPTION
After moving code signing inside the build, we've noticed a significant increase in build time and network issues causing build failures. This is happening because:
1. Signing a file requires a network call, and can take some time and is subject to possible networking issues
2. If a project gets rebuilt, we re-sign dlls even if CoreCompile was skipped because it's already been built before.
3. Signing NuGet files after CoreCompile is seen by MSBuild as an "update" on the project inputs, which triggers re-compilation on projects when it isn't necessary. Then, once that re-compile happens, the output dlls also need to be resigned.

These all compound upon each other and lead to a significant increase in build time and a decrease in reliability.

We can combine a few workarounds to fix this:
1. Ensure SignNugetFiles runs **before** CoreCompile, so build output still appears more recent than signed nugets.
2. When signing files, drop a temp file to indicate that it has already been signed. Do not sign files if the temp file exists.

Workaround 2 is implemented slightly differently for NuGet files and Output files. For build output, we simply drop a consistently named file in the OutDir, but for nuget files, we use the path of the dll to create the temp file, because we don't necessarily know the package path at the time of creating the file.


Given the "creative" nature of this workaround, we need to have a conversation about whether it's worth actually checking this in, or if we want to push for changes in the MicroBuild tooling instead and wait for those.