### PR TITLE
Update pipeline and pipeline info in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # android-tools
+[![Build Status](https://dev.azure.com/devdiv/DevDiv/_apis/build/status%2FXamarin%2FAndroid%2Fandroid-tools?branchName=main)](https://dev.azure.com/devdiv/DevDiv/_build/latest?definitionId=22338&branchName=main)
 
 **android-tools** is a repo to easily share code between the
 [xamarin-android][android] repo and the .NET for Android commercial tooling,
@@ -6,20 +7,6 @@ such as IDE extensions, without requiring that the IDE extensions
 submodule the entire **android** repo, which is gigantic.
 
 [android]: https://github.com/xamarin/xamarin-android
-
-# Build Status
-
-| Platform              | Status |
-|-----------------------|--------|
-| **macOS**             | [![macOS Build Status][azure-macOS-icon]][azure-macOS-status] |
-| **Windows**           | [![Windows Build Status][azure-Windows-icon]][azure-Windows-status] |
-
-
-[azure-macOS-icon]: https://dev.azure.com/xamarin/public/_apis/build/status/xamarin-android-tools
-[azure-macOS-status]: https://dev.azure.com/xamarin/public/_build/latest?definitionId=3
-[azure-Windows-icon]: https://dev.azure.com/xamarin/public/_apis/build/status/xamarin-android-tools
-[azure-Windows-status]: https://dev.azure.com/xamarin/public/_build/latest?definitionId=3
-
 
 # Build Requirements
 
@@ -71,7 +58,7 @@ The major version in the `nuget.version` file should be updated when a breaking 
 The minor version should be updated when new functionality is added.
 The patch version will be automatically determined by the number of commits since the last version change.
 
-Xamarin.Android.Tools.AndroidSdk nupkg files are produced for every build which occurrs on [Azure Devops](https://dev.azure.com/xamarin/Xamarin/_build?definitionId=2&_a=summary).
+Xamarin.Android.Tools.AndroidSdk nupkg files are produced for every build which occurrs on [Azure Devops](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=22338).
 To download one of these packages, navigate to the build you are interested in and click on the `Artifacts` button.
 
 Alternatively, "unofficial" releases are currently hosted on the [Xamarin.Android](https://dev.azure.com/xamarin/public/_packaging?_a=feed&feed=Xamarin.Android) feed.
@@ -84,8 +71,6 @@ Add the feed to your project's `NuGet.config` to reference these packages:
   </packageSources>
 </configuration>
 ```
-
-An Azure Pipelines [Release ](https://dev.azure.com/xamarin/public/_release?view=mine&_a=releases&definitionId=12) can be manually triggered to push a new version to this feed.
 
 # Mailing Lists
 

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -47,7 +47,7 @@ jobs:
       version: $(DotNetCoreVersion)
 
   - script: dotnet build Xamarin.Android.Tools.sln -bl:$(Build.ArtifactStagingDirectory)/build.binlog
-    displayName: 'Build solution Xamarin.Android.Tools.sln'
+    displayName: Build solution Xamarin.Android.Tools.sln
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Tests'

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -66,7 +66,8 @@ jobs:
     inputs:
       command: custom
       projects: src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
-      custom: pack -p:Version=$(xat.nuget.version) -p:PackageOutputPath=$(Build.ArtifactStagingDirectory) -bl:$(Build.ArtifactStagingDirectory)/pack.binlog
+      custom: pack
+      arguments: -p:Version=$(xat.nuget.version) -p:PackageOutputPath=$(Build.ArtifactStagingDirectory) -bl:$(Build.ArtifactStagingDirectory)/pack.binlog
     condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
   - task: PublishPipelineArtifact@1

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -64,9 +64,9 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: Build NuGet
     inputs:
-      command: pack
+      command: custom
       projects: src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
-      arguments: -p:Version=$(xat.nuget.version) -p:PackageOutputPath=$(Build.ArtifactStagingDirectory) -bl:$(Build.ArtifactStagingDirectory)/pack.binlog
+      arguments: pack -p:Version=$(xat.nuget.version) -p:PackageOutputPath=$(Build.ArtifactStagingDirectory) -bl:$(Build.ArtifactStagingDirectory)/pack.binlog
     condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
   - task: PublishPipelineArtifact@1

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -44,7 +44,7 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: Build solution Xamarin.Android.Tools.sln
     inputs:
-      projects: Xamarin.Android.sln
+      projects: Xamarin.Android.Tools.sln
       arguments: -bl:$(Build.ArtifactStagingDirectory)/build.binlog
 
   - task: DotNetCoreCLI@2

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -66,7 +66,7 @@ jobs:
     inputs:
       command: custom
       projects: src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
-      arguments: pack -p:Version=$(xat.nuget.version) -p:PackageOutputPath=$(Build.ArtifactStagingDirectory) -bl:$(Build.ArtifactStagingDirectory)/pack.binlog
+      custom: pack -p:Version=$(xat.nuget.version) -p:PackageOutputPath=$(Build.ArtifactStagingDirectory) -bl:$(Build.ArtifactStagingDirectory)/pack.binlog
     condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
   - task: PublishPipelineArtifact@1

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -1,4 +1,4 @@
-name: Android.Tools $(Rev:r)
+name: android-tools $(Rev:r)
 
 trigger:
 - main
@@ -47,7 +47,7 @@ jobs:
       version: $(DotNetCoreVersion)
 
   - script: dotnet build Xamarin.Android.Tools.sln -bl:$(Build.ArtifactStagingDirectory)/build.binlog
-    displayName: Build solution Xamarin.Android.Tools.sln
+    displayName: 'Build solution Xamarin.Android.Tools.sln'
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Tests'

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -10,7 +10,7 @@ pr:
 
 parameters:
 - name: ApiScanSourceBranch
-  default: 'refs/heads/main'
+  default: refs/heads/main
 
 # Global variables
 variables:
@@ -21,22 +21,17 @@ jobs:
 - job: build
   displayName: Build and Test
   timeoutInMinutes: 60
-  cancelTimeoutInMinutes: 2
-
   strategy:
     matrix:
       macOS:
-        vmImage: macOS-12
+        vmImage: macOS-13
       windows:
         vmImage: windows-2022
         Codeql.Enabled: true
-
   pool:
     vmImage: $(vmImage)
-
   workspace:
     clean: all
-
   steps:
   - checkout: self
     clean: true
@@ -46,11 +41,14 @@ jobs:
     inputs:
       version: $(DotNetCoreVersion)
 
-  - script: dotnet build Xamarin.Android.Tools.sln -bl:$(Build.ArtifactStagingDirectory)/build.binlog
-    displayName: 'Build solution Xamarin.Android.Tools.sln'
+  - task: DotNetCoreCLI@2
+    displayName: Build solution Xamarin.Android.Tools.sln
+    inputs:
+      projects: Xamarin.Android.sln
+      arguments: -bl:$(Build.ArtifactStagingDirectory)/build.binlog
 
   - task: DotNetCoreCLI@2
-    displayName: 'Run Tests'
+    displayName: Run Tests
     inputs:
       command: test
       projects: bin/TestDebug-net*/**/*-Tests.dll
@@ -63,8 +61,12 @@ jobs:
       Write-Host "##vso[task.setvariable variable=xat.nuget.version]$version"
     condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
-  - script: dotnet pack src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj -p:Version=$(xat.nuget.version) -p:PackageOutputPath=$(Build.ArtifactStagingDirectory) -bl:$(Build.ArtifactStagingDirectory)/pack.binlog
-    displayName: 'Build NuGet'
+  - task: DotNetCoreCLI@2
+    displayName: Build NuGet
+    inputs:
+      command: pack
+      projects: src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj
+      arguments: -p:Version=$(xat.nuget.version) -p:PackageOutputPath=$(Build.ArtifactStagingDirectory) -bl:$(Build.ArtifactStagingDirectory)/pack.binlog
     condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
   - task: PublishPipelineArtifact@1


### PR DESCRIPTION
The pipeline has been moved to the devdiv org, and in the future can be
split into public/internal pipelines in the dotnet org if necessary.