### PR TITLE
Be explicit about FileShare mode when using FileStream.

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -435,7 +435,7 @@ namespace Microsoft.Android.Build.Tasks
 
 		public static string HashFile (string filename, HashAlgorithm hashAlg)
 		{
-			using (Stream file = new FileStream (filename, FileMode.Open, FileAccess.Read)) {
+			using (Stream file = new FileStream (filename, FileMode.Open, FileAccess.Read, FileShare.Read)) {
 				byte[] hash = hashAlg.ComputeHash (file);
 				return ToHexString (hash);
 			}
@@ -479,7 +479,7 @@ namespace Microsoft.Android.Build.Tasks
 		public static bool IsPortablePdb (string filename)
 		{
 			try {
-				using (var fs = new FileStream (filename, FileMode.Open, FileAccess.Read)) {
+				using (var fs = new FileStream (filename, FileMode.Open, FileAccess.Read, FileShare.Read)) {
 					using (var br = new BinaryReader (fs)) {
 						return br.ReadUInt32 () == ppdb_signature;
 					}


### PR DESCRIPTION
Context https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2055618

We know that by default `FileShare` will be `Read` when using a `FileStream`. However lets be totally clear on what we want from this point on, so if there is a problem we know its not us.