### PR TITLE
Bump to dotnet/msbuild@10fbfbf2

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
+++ b/src/Microsoft.Android.Build.BaseTasks/MSBuildReferences.projitems
@@ -4,8 +4,7 @@
 <Project>
   <!--Import this file in projects needing to reference Microsoft.Build.*.dll -->
   <PropertyGroup>
-    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.9.5</MSBuildPackageReferenceVersion>
-    <SystemSecurityCryptographyXmlVersion Condition=" '$(SystemSecurityCryptographyXmlVersion)' == '' ">7.0.1</SystemSecurityCryptographyXmlVersion>
+    <MSBuildPackageReferenceVersion Condition=" '$(MSBuildPackageReferenceVersion)' == '' ">17.10.4</MSBuildPackageReferenceVersion>
     <LibZipSharpVersion Condition=" '$(LibZipSharpVersion)' == '' " >3.3.0</LibZipSharpVersion>
     <MonoUnixVersion>7.1.0-final.1.21458.1</MonoUnixVersion>
   </PropertyGroup>
@@ -15,7 +14,8 @@
     <PackageReference Include="Microsoft.Build.Framework"      Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core"     Version="$(MSBuildPackageReferenceVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageReferenceVersion)" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
+    <!-- Explicitly update the System.Formats.Asn1 transitive dependency of Microsoft.Build to address https://github.com/advisories/GHSA-447r-wph3-92pm -->
+    <PackageReference Include="System.Formats.Asn1" Version="8.0.1" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.1.11" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(LibZipSharpVersion)" GeneratePathProperty="true" />
     <PackageReference Include="Mono.Unix" Version="$(MonoUnixVersion)" GeneratePathProperty="true" />


### PR DESCRIPTION
Changes: https://github.com/dotnet/msbuild/compare/v17.9.5...v17.10.4

Updates $(MSBuildPackageReferenceVersion) to the latest VS 2022 LTS.

This new package version brings in System.Security.Cryptography.Xml
v8.0.0 as a transitive dependency, and as such the explicit v7.0.1
package reference should no longer be necessary.

An explicit package reference has been added for System.Formats.Asn1
v8.0.1 (another transitive dependency of Microsoft.Build) to address
https://github.com/advisories/GHSA-447r-wph3-92pm.