### PR TITLE
[Microsoft.Android.Build.BaseTasks] report locked files for UnauthorizedAccessException

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/UnhandledExceptionLogger.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/UnhandledExceptionLogger.cs
@@ -62,8 +62,8 @@ namespace Microsoft.Android.Build.Tasks
 				logCodedError (prefix + "7017", ex.ToString ());
 			else if (ex is TypeInitializationException)
 				logCodedError (prefix + "7018", ex.ToString ());
-			else if (ex is UnauthorizedAccessException)
-				logCodedError (prefix + "7019", ex.ToString ());
+			else if (ex is UnauthorizedAccessException uaex)
+				logCodedError (prefix + "7019", GetFileLockedExceptionMessage (uaex));
 			else if (ex is ApplicationException)
 				logCodedError (prefix + "7020", ex.ToString ());
 			else if (ex is KeyNotFoundException)
@@ -81,12 +81,12 @@ namespace Microsoft.Android.Build.Tasks
 			else if (ex is FileNotFoundException)		// IOException
 				logCodedError (prefix + "7028", ex.ToString ());
 			else if (ex is IOException ioex)
-				logCodedError (prefix + "7024", GetIOExceptionMessage (ioex));
+				logCodedError (prefix + "7024", GetFileLockedExceptionMessage (ioex));
 			else
 				logCodedError (prefix + "7000", ex.ToString ());
 		}
 
-		static string GetIOExceptionMessage (IOException ex)
+		static string GetFileLockedExceptionMessage (Exception ex)
 		{
 			// If we find a file path in the message, and the file exists, check if it's locked
 			// en-US message is:


### PR DESCRIPTION
Context: https://github.com/dotnet/android/issues/9133

In the above issue, a customer got:

    error XARDF7019: System.UnauthorizedAccessException: Access to the path 'GoogleGson.dll' is denied.
    at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, Boolean throwOnTopLevelDirectoryNotFound, WIN32_FIND_DATA& data)
    at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
    at Xamarin.Android.Tasks.RemoveDirFixed.RunTask() in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs:line 54	MauiApp2 (net9.0-android)	C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\34.99.0-preview.6.340\tools\Xamarin.Android.Common.targets

Let's expand upon 11fad9d5 to include `UnauthorizedAccessException`.

Unfortunately, I wasn't able to *reproduce* this exception, I tried several things:

* `File.Delete` on a file

* `File.Delete` on the currently running test assembly

* `File.SetAttributes` to `ReadOnly` on a file

* `Directory.Delete` on a directory with readonly files

I settled on just throwing `UnauthorizedAccessException` with the exact same message reported in dotnet/android#9133. It may or may not work, depending on if the message has a valid path to the file.

This still seems useful though -- better than nothing.