### PR TITLE
Add a retry attempt when copying files

### DIFF
--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -160,8 +160,7 @@ namespace Microsoft.Android.Build.Tasks
 			int retryCount = 0;
 			int attempts = GetFileWriteRetryAttempts ();
 			int delay = GetFileWriteRetryDelay ();
-			while (retryCount < attempts) {
-				Console.WriteLine ($"{nameof(CopyIfChanged)}: Copy Attempt {retryCount}.");
+			while (retryCount <= attempts) {
 				try {
 					return CopyIfChangedRetry (source, destination);
 				} catch (Exception e) {
@@ -170,7 +169,6 @@ namespace Microsoft.Android.Build.Tasks
 						case IOException:
 							int code = Marshal.GetHRForException (e);
 							if ((code != ERROR_ACCESS_DENIED && code != ERROR_SHARING_VIOLATION) || retryCount == attempts) {
-								Console.WriteLine ($"{nameof(CopyIfChanged)}: Throwing {e}\ncode:{code}\nretryCount:{retryCount}.");
 								throw;
 							};
 							break;
@@ -179,7 +177,6 @@ namespace Microsoft.Android.Build.Tasks
 					} 
 				}
 				retryCount++;
-				Console.WriteLine ($"{nameof(CopyIfChanged)}: Copy Sleeping {delay}.");
 				Thread.Sleep (delay);
 			}
 			return false;
@@ -236,7 +233,7 @@ namespace Microsoft.Android.Build.Tasks
 			int retryCount = 0;
 			int attempts = GetFileWriteRetryAttempts ();
 			int delay = GetFileWriteRetryDelay ();
-			while (retryCount < attempts) {
+			while (retryCount <= attempts) {
 				try {
 					return CopyIfStreamChangedRetry (stream, destination);
 				} catch (Exception e) {

--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Android.Build.Tasks
 					switch (e) {
 						case UnauthorizedAccessException:
 						case IOException:
-							int code = Marshal.GetHRForException(e);
+							int code = Marshal.GetHRForException (e);
 							if (code != ERROR_ACCESS_DENIED || retryCount == DEFAULT_COPYIFCHANGED_RETRIES) {
 								throw;
 							};
@@ -138,7 +138,7 @@ namespace Microsoft.Android.Build.Tasks
 					} 
 				}
 				retryCount++;
-				Thread.Sleep(DEFAULT_FILE_WRITE_RETRY_DELAY_MS);
+				Thread.Sleep (DEFAULT_FILE_WRITE_RETRY_DELAY_MS);
 			}
 			return false;
 		}
@@ -199,7 +199,7 @@ namespace Microsoft.Android.Build.Tasks
 					switch (e) {
 						case UnauthorizedAccessException:
 						case IOException:
-							int code = Marshal.GetHRForException(e);
+							int code = Marshal.GetHRForException (e);
 							if (code != ERROR_ACCESS_DENIED || retryCount == DEFAULT_COPYIFCHANGED_RETRIES) {
 								throw;
 							};
@@ -209,7 +209,7 @@ namespace Microsoft.Android.Build.Tasks
 					} 
 				}
 				retryCount++;
-				Thread.Sleep(DEFAULT_FILE_WRITE_RETRY_DELAY_MS);
+				Thread.Sleep (DEFAULT_FILE_WRITE_RETRY_DELAY_MS);
 			}
 			return false;
 		}

--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Android.Build.Tasks
 			int delay = GetFileWriteRetryDelay ();
 			while (retryCount <= attempts) {
 				try {
-					return CopyIfChangedRetry (source, destination);
+					return CopyIfChangedOnce (source, destination);
 				} catch (Exception e) {
 					switch (e) {
 						case UnauthorizedAccessException:
@@ -182,7 +182,7 @@ namespace Microsoft.Android.Build.Tasks
 			return false;
 		}
 
-		public static bool CopyIfChangedRetry (string source, string destination)
+		public static bool CopyIfChangedOnce (string source, string destination)
 		{
 			if (HasFileChanged (source, destination)) {
 				var directory = Path.GetDirectoryName (destination);
@@ -235,7 +235,7 @@ namespace Microsoft.Android.Build.Tasks
 			int delay = GetFileWriteRetryDelay ();
 			while (retryCount <= attempts) {
 				try {
-					return CopyIfStreamChangedRetry (stream, destination);
+					return CopyIfStreamChangedOnce (stream, destination);
 				} catch (Exception e) {
 					switch (e) {
 						case UnauthorizedAccessException:
@@ -255,7 +255,7 @@ namespace Microsoft.Android.Build.Tasks
 			return false;
 		}
 
-		public static bool CopyIfStreamChangedRetry (Stream stream, string destination)
+		public static bool CopyIfStreamChangedOnce (Stream stream, string destination)
 		{
 			if (HasStreamChanged (stream, destination)) {
 				var directory = Path.GetDirectoryName (destination);

--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Android.Build.Tasks
 						case UnauthorizedAccessException:
 						case IOException:
 							int code = Marshal.GetHRForException (e);
-							if ((code != ERROR_ACCESS_DENIED && code != ERROR_SHARING_VIOLATION) || retryCount == attempts) {
+							if ((code != ERROR_ACCESS_DENIED && code != ERROR_SHARING_VIOLATION) || retryCount >= attempts) {
 								throw;
 							};
 							break;

--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -24,6 +24,9 @@ namespace Microsoft.Android.Build.Tasks
 
 		const int DEFAULT_FILE_WRITE_RETRY_DELAY_MS = 1000;
 
+		static int fileWriteRetry = -1;
+		static int fileWriteRetryDelay = -1;
+
 		/// <summary>
 		/// Windows has a MAX_PATH limit of 260 characters
 		/// See: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation
@@ -46,10 +49,12 @@ namespace Microsoft.Android.Build.Tasks
 		/// <returns>The value of DOTNET_ANDROID_FILE_WRITE_RETRY_ATTEMPTS or the default of DEFAULT_FILE_WRITE_RETRY_ATTEMPTS</returns>
 		public static int GetFileWriteRetryAttempts ()
 		{
-			var retryVariable = Environment.GetEnvironmentVariable ("DOTNET_ANDROID_FILE_WRITE_RETRY_ATTEMPTS");
-			if (!string.IsNullOrEmpty (retryVariable) && int.TryParse (retryVariable, out int retry))
-				return retry;
-			return DEFAULT_FILE_WRITE_RETRY_ATTEMPTS;
+			if (fileWriteRetry == -1) {
+				var retryVariable = Environment.GetEnvironmentVariable ("DOTNET_ANDROID_FILE_WRITE_RETRY_ATTEMPTS");
+				if (string.IsNullOrEmpty (retryVariable) || !int.TryParse (retryVariable, out fileWriteRetry))
+					fileWriteRetry = DEFAULT_FILE_WRITE_RETRY_ATTEMPTS;
+			}
+			return fileWriteRetry;
 		}
 
 		/// <summary>
@@ -60,10 +65,12 @@ namespace Microsoft.Android.Build.Tasks
 		/// <returns>The value of DOTNET_ANDROID_FILE_WRITE_RETRY_DELAY_MS or the default of DEFAULT_FILE_WRITE_RETRY_DELAY_MS</returns>
 		public static int GetFileWriteRetryDelay ()
 		{
-			var delayVariable = Environment.GetEnvironmentVariable ("DOTNET_ANDROID_FILE_WRITE_RETRY_DELAY_MS");
-			if (!string.IsNullOrEmpty (delayVariable) && int.TryParse (delayVariable, out int delay))
-				return delay;
-			return DEFAULT_FILE_WRITE_RETRY_DELAY_MS;
+			if (fileWriteRetryDelay == -1) {
+				var delayVariable = Environment.GetEnvironmentVariable ("DOTNET_ANDROID_FILE_WRITE_RETRY_DELAY_MS");
+				if (string.IsNullOrEmpty (delayVariable) || !int.TryParse (delayVariable, out fileWriteRetryDelay))
+					fileWriteRetryDelay = DEFAULT_FILE_WRITE_RETRY_DELAY_MS;
+			}
+			return fileWriteRetryDelay;
 		} 
 		/// <summary>
 		/// Converts a full path to a \\?\ prefixed path that works on all Windows machines when over 260 characters

--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -160,6 +160,7 @@ namespace Microsoft.Android.Build.Tasks
 			int attempts = GetFileWriteRetryAttempts ();
 			int delay = GetFileWriteRetryDelay ();
 			while (retryCount < attempts) {
+				Console.WriteLine ($"{nameof(CopyIfChanged)}: Copy Attempt {retryCount}.");
 				try {
 					return CopyIfChangedRetry (source, destination);
 				} catch (Exception e) {
@@ -168,6 +169,7 @@ namespace Microsoft.Android.Build.Tasks
 						case IOException:
 							int code = Marshal.GetHRForException (e);
 							if (code != ERROR_ACCESS_DENIED || retryCount == attempts) {
+								Console.WriteLine ($"{nameof(CopyIfChanged)}: Throwing {code} {retryCount}.");
 								throw;
 							};
 							break;
@@ -176,6 +178,7 @@ namespace Microsoft.Android.Build.Tasks
 					} 
 				}
 				retryCount++;
+				Console.WriteLine ($"{nameof(CopyIfChanged)}: Copy Sleeping {delay}.");
 				Thread.Sleep (delay);
 			}
 			return false;

--- a/src/Microsoft.Android.Build.BaseTasks/Files.cs
+++ b/src/Microsoft.Android.Build.BaseTasks/Files.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Android.Build.Tasks
 {
 	public static class Files
 	{
-		const int ERROR_ACCESS_DENIED = 5;
+		const int ERROR_ACCESS_DENIED = -2147024891;
+		const int ERROR_SHARING_VIOLATION = -2147024864;
 
 		const int DEFAULT_FILE_WRITE_RETRY_ATTEMPTS = 10;
 
@@ -168,8 +169,8 @@ namespace Microsoft.Android.Build.Tasks
 						case UnauthorizedAccessException:
 						case IOException:
 							int code = Marshal.GetHRForException (e);
-							if (code != ERROR_ACCESS_DENIED || retryCount == attempts) {
-								Console.WriteLine ($"{nameof(CopyIfChanged)}: Throwing {code} {retryCount}.");
+							if ((code != ERROR_ACCESS_DENIED && code != ERROR_SHARING_VIOLATION) || retryCount == attempts) {
+								Console.WriteLine ($"{nameof(CopyIfChanged)}: Throwing {e}\ncode:{code}\nretryCount:{retryCount}.");
 								throw;
 							};
 							break;
@@ -243,7 +244,7 @@ namespace Microsoft.Android.Build.Tasks
 						case UnauthorizedAccessException:
 						case IOException:
 							int code = Marshal.GetHRForException (e);
-							if (code != ERROR_ACCESS_DENIED || retryCount == attempts) {
+							if ((code != ERROR_ACCESS_DENIED && code != ERROR_SHARING_VIOLATION) || retryCount == attempts) {
 								throw;
 							};
 							break;

--- a/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj
+++ b/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <AssemblyName>$(VendorPrefix)Microsoft.Android.Build.BaseTasks$(VendorSuffix)</AssemblyName>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>13.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj
+++ b/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj
@@ -9,6 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <AssemblyName>$(VendorPrefix)Microsoft.Android.Build.BaseTasks$(VendorSuffix)</AssemblyName>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj
+++ b/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <AssemblyName>$(VendorPrefix)Microsoft.Android.Build.BaseTasks$(VendorSuffix)</AssemblyName>
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
@@ -450,7 +450,7 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 			src = NewFile (contents: "foo2", fileName: "foo");
 			Task.Run (async () => {
 				using (var file = File.OpenWrite (dest)) {
-					await Task.Delay (500);
+					await Task.Delay (200);
 				}
 			});
 			Assert.IsTrue (Files.CopyIfChanged (src, dest));

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xamarin.Tools.Zip;
 using Microsoft.Android.Build.Tasks;
@@ -448,16 +449,18 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 			src = NewFile (contents: "foo1", fileName: "foo");
 			Assert.IsTrue (Files.CopyIfChanged (src, dest));
 			src = NewFile (contents: "foo2", fileName: "foo");
+			var ev = new ManualResetEvent (false);
 			var task = Task.Run (async () => {
 				var file = File.Open (dest, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read);
 				try {
+					ev.Set ();
 					await Task.Delay (2500);
 				} finally {
 					file.Close();
 					file.Dispose ();
 				}
 			});
-			await Task.Delay (1000);
+			ev.WaitOne ();
 			Assert.IsTrue (Files.CopyIfChanged (src, dest));
 			await task;
 		}

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
@@ -451,7 +451,7 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 			var task = Task.Run (async () => {
 				var file = File.Open (dest, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read);
 				try {
-					await Task.Delay (200);
+					await Task.Delay (2500);
 				} finally {
 					file.Close();
 					file.Dispose ();

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
@@ -449,6 +449,7 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 			src = NewFile (contents: "foo1", fileName: "foo");
 			Assert.IsTrue (Files.CopyIfChanged (src, dest));
 			src = NewFile (contents: "foo2", fileName: "foo");
+			dest = NewFile (contents: "foo", fileName: "foo_locked2");
 			var ev = new ManualResetEvent (false);
 			var task = Task.Run (async () => {
 				var file = File.Open (dest, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read);

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
@@ -441,10 +441,11 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 		public void CopyIfChanged_LockedFile ()
 		{
 			var dest = NewFile (contents: "foo", fileName: "foo_locked");
-			var src = NewFile (contents: "foo", fileName: "foo");
+			var src = NewFile (contents: "foo0", fileName: "foo");
 			using (var file = File.OpenWrite (dest)) {
 				Assert.Throws<IOException> (() => Files.CopyIfChanged (src, dest));
 			}
+			src = NewFile (contents: "foo1", fileName: "foo");
 			Assert.IsTrue (Files.CopyIfChanged (src, dest));
 			src = NewFile (contents: "foo2", fileName: "foo");
 			Task.Run (async () => {

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading.Tasks;
 using Xamarin.Tools.Zip;
 using Microsoft.Android.Build.Tasks;
 
@@ -442,8 +443,15 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 			var dest = NewFile (contents: "foo", fileName: "foo_locked");
 			var src = NewFile (contents: "foo", fileName: "foo");
 			using (var file = File.OpenWrite (dest)) {
-				Assert.IsFalse (Files.CopyIfChanged (src, dest));
+				Assert.Throws<IOException> (() => Files.CopyIfChanged (src, dest));
 			}
+			Assert.IsTrue (Files.CopyIfChanged (src, dest));
+			src = NewFile (contents: "foo2", fileName: "foo");
+			Task.Run (async () => {
+				using (var file = File.OpenWrite (dest)) {
+					await Task.Delay (500);
+				}
+			});
 			Assert.IsTrue (Files.CopyIfChanged (src, dest));
 		}
 

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
@@ -437,6 +437,17 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 		}
 
 		[Test]
+		public void CopyIfChanged_LockedFile ()
+		{
+			var dest = NewFile (contents: "foo", fileName: "foo_locked");
+			var src = NewFile (contents: "foo", fileName: "foo");
+			using (var file = File.OpenWrite (dest)) {
+				Assert.IsFalse (Files.CopyIfChanged (src, dest));
+			}
+			Assert.IsTrue (Files.CopyIfChanged (src, dest));
+		}
+
+		[Test]
 		public void ExtractAll ()
 		{
 			using (var zip = ZipArchive.Create (stream)) {

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
@@ -449,7 +449,7 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 			Assert.IsTrue (Files.CopyIfChanged (src, dest));
 			src = NewFile (contents: "foo2", fileName: "foo");
 			var task = Task.Run (async () => {
-				var file = File.OpenWrite (dest);
+				var file = File.Open (dest, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Read);
 				try {
 					await Task.Delay (200);
 				} finally {

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
@@ -438,7 +438,7 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 		}
 
 		[Test]
-		public void CopyIfChanged_LockedFile ()
+		public async Task CopyIfChanged_LockedFile ()
 		{
 			var dest = NewFile (contents: "foo", fileName: "foo_locked");
 			var src = NewFile (contents: "foo0", fileName: "foo");
@@ -448,12 +448,17 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 			src = NewFile (contents: "foo1", fileName: "foo");
 			Assert.IsTrue (Files.CopyIfChanged (src, dest));
 			src = NewFile (contents: "foo2", fileName: "foo");
-			Task.Run (async () => {
-				using (var file = File.OpenWrite (dest)) {
+			var task = Task.Run (async () => {
+				var file = File.OpenWrite (dest);
+				try {
 					await Task.Delay (200);
+				} finally {
+					file.Close();
+					file.Dispose ();
 				}
 			});
 			Assert.IsTrue (Files.CopyIfChanged (src, dest));
+			await task;
 		}
 
 		[Test]

--- a/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
+++ b/tests/Microsoft.Android.Build.BaseTasks-Tests/FilesTests.cs
@@ -457,6 +457,7 @@ namespace Microsoft.Android.Build.BaseTasks.Tests
 					file.Dispose ();
 				}
 			});
+			await Task.Delay (1000);
 			Assert.IsTrue (Files.CopyIfChanged (src, dest));
 			await task;
 		}


### PR DESCRIPTION
Context https://github.com/dotnet/android/issues/9133.

We get collisions between the DTB (or AV) and our main build. This can result in the following error

```
Error (active)	XALNS7019	System.UnauthorizedAccessException: Access to the path 'D:\Projects\MauiApp2\obj\Debug\net9.0-android\android\assets\armeabi-v7a\MauiApp2.dll' is denied.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.File.InternalDelete(String path, Boolean checkHost)
   at Microsoft.Android.Build.Tasks.Files.CopyIfChanged(String source, String destination) in /Users/runner/work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/Files.cs:line 125
   at Xamarin.Android.Tasks.MonoAndroidHelper.CopyAssemblyAndSymbols(String source, String destination) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs:line 344
   at Xamarin.Android.Tasks.LinkAssembliesNoShrink.CopyIfChanged(ITaskItem source, ITaskItem destination) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs:line 161
   at Xamarin.Android.Tasks.LinkAssembliesNoShrink.RunTask() in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/LinkAssembliesNoShrink.cs:line 76
   at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/runner/work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/AndroidTask.cs:line 25	MauiApp2 (net9.0-android)	C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\34.99.0-preview.6.340\tools\Xamarin.Android.Common.targets	1407
```

If we look at the MSBuild [Copy](https://github.com/dotnet/msbuild/blob/main/src/Tasks/Copy.cs#L897) task we see that it has a retry system in the cases of `UnauthorizedAccessException` or `IOException` when the code is `ACCESS_DENIED` or `ERROR_SHARING_VIOLATION`. So lets duplicate that kind of logic in our `Copy*IfChanged` helper methods. This should give our builds a bit more resiliency to these kinds of issues.