### PR TITLE
Add support to discovering activity-alias activity elements

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidAppManifest.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidAppManifest.cs
@@ -6,7 +6,6 @@ using System.Xml.Linq;
 using System.Text.RegularExpressions;
 using System.Text;
 using System.IO;
-using System.Collections;
 
 namespace Xamarin.Android.Tools
 {
@@ -330,8 +329,8 @@ namespace Xamarin.Android.Tools
 
 		IEnumerable<XElement> GetLaunchableActivities ()
 		{
-			var activities = application.Elements ("activity") ?? Enumerable.Empty<XElement> ();
-			var aliases = application.Elements ("activity-alias") ?? Enumerable.Empty<XElement> ();
+			var activities = application.Elements ("activity");
+			var aliases = application.Elements ("activity-alias");
 			foreach (var activity in activities.Union (aliases)) {
 				foreach (var filter in activity.Elements ("intent-filter")) {
 					foreach (var category in filter.Elements ("category"))

--- a/src/Xamarin.Android.Tools.AndroidSdk/AndroidAppManifest.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/AndroidAppManifest.cs
@@ -6,6 +6,7 @@ using System.Xml.Linq;
 using System.Text.RegularExpressions;
 using System.Text;
 using System.IO;
+using System.Collections;
 
 namespace Xamarin.Android.Tools
 {
@@ -329,7 +330,9 @@ namespace Xamarin.Android.Tools
 
 		IEnumerable<XElement> GetLaunchableActivities ()
 		{
-			foreach (var activity in application.Elements ("activity")) {
+			var activities = application.Elements ("activity") ?? Enumerable.Empty<XElement> ();
+			var aliases = application.Elements ("activity-alias") ?? Enumerable.Empty<XElement> ();
+			foreach (var activity in activities.Union (aliases)) {
 				foreach (var filter in activity.Elements ("intent-filter")) {
 					foreach (var category in filter.Elements ("category"))
 						if (category != null && (string?)category.Attribute (aName) == "android.intent.category.LAUNCHER")

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidAppManifestTests.cs
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/AndroidAppManifestTests.cs
@@ -51,8 +51,9 @@ namespace Xamarin.Android.Tools.Tests
 			var versions	= new AndroidVersions (Array.Empty<AndroidVersion>());
 			var manifest    = AndroidAppManifest.Load (GetTestAppManifest (), versions);
 			var launchers   = manifest.GetLaunchableActivityNames ().ToList ();
-			Assert.AreEqual (1,                             launchers.Count);
+			Assert.AreEqual (2,                             launchers.Count);
 			Assert.AreEqual (".HasMultipleIntentFilters",	launchers [0]);
+			Assert.AreEqual (".ActivityAlias",	launchers [1]);
 		}
 
 		[Test]

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Resources/manifest-simplewidget.xml
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Resources/manifest-simplewidget.xml
@@ -33,6 +33,12 @@
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
     </activity>
+    <activity-alias android:name=".ActivityAlias" android:label="alias">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity-alias>
   </application>
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.READ_CONTACTS" />

--- a/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj
+++ b/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj
@@ -4,7 +4,7 @@
     <!-- $(TargetFrameworks) is used to allow the $(TargetFramework) check in Directory.Build.props to work.
         If $(TargetFramework) is declared here instead, it will not be evaluated before Directory.Build.props
         is loaded and the wrong $(TestOutputFullPath) will be used. -->
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Context https://developer.android.com/guide/topics/manifest/activity-alias-element.
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2305723.

So activity-alias allows users to change some settings before calling an activity. 
The idea is that your activity is no longer the main launcher, you still have that entry, but the activity-alias' become the main launchers.
Here is a sample AndroidManifest.xml

```xml
<?xml version="1.0" encoding="utf-8"?>
<manifest xmlns:android="http://schemas.android.com/apk/res/android">
	<application
		android:allowBackup="true"
		android:icon="@mipmap/appicon"
		android:roundIcon="@mipmap/appicon_round"
		android:supportsRtl="true">
		<activity-alias
			android:name=".MainActivityAlias"
			android:enabled="true"
			android:icon="@mipmap/appicon"
			android:targetActivity=".MainActivity"
			android:exported="true">
			<intent-filter>
				<action android:name="android.intent.action.MAIN" />
				<category android:name="android.intent.category.LAUNCHER" />
			</intent-filter>
		</activity-alias>
		<activity-alias
			android:name=".MainActivityAlias2"
			android:enabled="false"
			android:icon="@mipmap/appicon2"
			android:targetActivity=".MainActivity"
			android:exported="true">
			<intent-filter>
				<action android:name="android.intent.action.MAIN" />
				<category android:name="android.intent.category.LAUNCHER" />
			</intent-filter>
		</activity-alias>
	</application>
	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
	<uses-permission android:name="android.permission.INTERNET" />
</manifest>
```

The `MainActivity.cs` then becomes

```csharp
[Activity(Theme = "@style/Maui.SplashTheme", LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
    [Register("com.companyname.mauiappwithmultipleicons.MainActivity")]
    public class MainActivity : MauiAppCompatActivity
```

Note that we do not use the MainLauncher property on the ActivityAttribute.