### PR TITLE
Remove hardcoded Path

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Sdks/AndroidSdkWindows.cs
@@ -106,7 +106,6 @@ namespace Xamarin.Android.Tools
 					: Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.ProgramFiles), "Android", "android-sdk"),
 				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.LocalApplicationData), "Android", "android-sdk"),
 				Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.CommonApplicationData), "Android", "android-sdk"),
-				@"C:\android-sdk-windows"
 			};
 			foreach (var basePath in paths)
 				if (Directory.Exists (basePath))


### PR DESCRIPTION
Context https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2341994

Remove the hardcoded  path to `C:\android-sdk-windows` from the list of backup paths to check when scanning for the android sdk.