### PR TITLE
[Xamarin.Android.Tools.AndroidSdk] Don't check Linux paths on Windows

### DIFF
--- a/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
@@ -383,6 +383,10 @@ namespace Xamarin.Android.Tools
 
 		static IEnumerable<string> GetLibexecJdkPaths (Action<TraceLevel, string> logger)
 		{
+			if (!OS.IsLinux) {
+				yield break;
+			}
+
 			var java_home	= Path.GetFullPath ("/usr/libexec/java_home");
 			if (!File.Exists (java_home)) {
 				yield break;
@@ -429,6 +433,10 @@ namespace Xamarin.Android.Tools
 
 		static IEnumerable<string> GetJavaAlternativesJdkPaths ()
 		{
+			if (!OS.IsLinux) {
+				return Enumerable.Empty<string> ();
+			}
+
 			var alternatives  = Path.GetFullPath ("/usr/sbin/update-java-alternatives");
 			if (!File.Exists (alternatives))
 				return Enumerable.Empty<string> ();
@@ -464,6 +472,10 @@ namespace Xamarin.Android.Tools
 
 		static IEnumerable<string> GetLibJvmJdkPaths ()
 		{
+			if (!OS.IsLinux) {
+				yield break;
+			}
+
 			var jvm = "/usr/lib/jvm";
 			if (!Directory.Exists (jvm))
 				yield break;

--- a/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/JdkInfo.cs
@@ -383,7 +383,7 @@ namespace Xamarin.Android.Tools
 
 		static IEnumerable<string> GetLibexecJdkPaths (Action<TraceLevel, string> logger)
 		{
-			if (!OS.IsLinux) {
+			if (!OS.IsMac) {
 				yield break;
 			}
 

--- a/src/Xamarin.Android.Tools.AndroidSdk/Jdks/MicrosoftDistJdkLocations.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/Jdks/MicrosoftDistJdkLocations.cs
@@ -18,6 +18,10 @@ namespace Xamarin.Android.Tools {
 
 		static IEnumerable<string> GetMacOSMicrosoftDistJdkPaths ()
 		{
+			if (!OS.IsMac) {
+				return Array.Empty<string> ();
+			}
+
 			var jdks    = AppDomain.CurrentDomain.GetData ($"GetMacOSMicrosoftJdkPaths jdks override! {typeof (JdkInfo).AssemblyQualifiedName}")
 				?.ToString ();
 			if (jdks == null) {

--- a/src/Xamarin.Android.Tools.AndroidSdk/OS.cs
+++ b/src/Xamarin.Android.Tools.AndroidSdk/OS.cs
@@ -11,6 +11,7 @@ namespace Xamarin.Android.Tools
 	{
 		public readonly static bool IsWindows;
 		public readonly static bool IsMac;
+		public readonly static bool IsLinux;
 
 		internal readonly static string? ProgramFilesX86;
 
@@ -20,6 +21,7 @@ namespace Xamarin.Android.Tools
 		{
 			IsWindows = Path.DirectorySeparatorChar == '\\';
 			IsMac = !IsWindows && IsRunningOnMac ();
+			IsLinux = !IsWindows && !IsMac;
 
 			if (IsWindows) {
 				ProgramFilesX86 = GetProgramFilesX86 ();
@@ -29,7 +31,7 @@ namespace Xamarin.Android.Tools
 				NativeLibraryFormat = "{0}.dll";
 			if (IsMac)
 				NativeLibraryFormat = "lib{0}.dylib";
-			if (!IsWindows && !IsMac)
+			if (IsLinux)
 				NativeLibraryFormat = "lib{0}.so";
 		}
 


### PR DESCRIPTION
OS-specific JDK locators should only be used on the OS that they're intended for.  Remove checks for Linux JDK probe mechanisms such as `/usr/libexec/java_home` and `/usr/lib/jvm/*` from Windows & macOS.