### PR TITLE
[build] set `$(PackageVersion)`

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,9 +7,10 @@
     <GitDefaultBranch>main</GitDefaultBranch>
   </PropertyGroup>
 
-  <Target Name="SetVersion" BeforeTargets="GetAssemblyVersion;GetPackageVersion" DependsOnTargets="GitVersion">
+  <Target Name="SetVersion" BeforeTargets="GetAssemblyVersion;GetPackageVersion;GenerateNuspec" DependsOnTargets="GitVersion">
     <PropertyGroup>
       <Version>$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)</Version>
+      <PackageVersion>$(Version)</PackageVersion>
       <InformationalVersion>$(Version); git-rev-head:$(GitCommit); git-branch:$(GitBranch)</InformationalVersion>
     </PropertyGroup>
   </Target>


### PR DESCRIPTION
To be able to distribute things in this repo as a NuGet package, we need to set `$(PackageVersion)` appropriately.