### PR TITLE
[build] introduce `$(PackageVersionSuffix)` for dotnet/android

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -10,7 +10,7 @@
   <Target Name="SetVersion" BeforeTargets="GetAssemblyVersion;GetPackageVersion;GenerateNuspec" DependsOnTargets="GitVersion">
     <PropertyGroup>
       <Version>$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)</Version>
-      <PackageVersion>$(Version)</PackageVersion>
+      <PackageVersion>$(Version)$(PackageVersionSuffix)</PackageVersion>
       <InformationalVersion>$(Version); git-rev-head:$(GitCommit); git-branch:$(GitBranch)</InformationalVersion>
     </PropertyGroup>
   </Target>


### PR DESCRIPTION
This allows dotnet/android to add a `-preview.$(PackVersionCommitCount)` suffix for any `.nupkg` packages produced by this repo.